### PR TITLE
specify elixir and erlang versions for asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 25.0.1
+elixir 1.13.4-otp-25


### PR DESCRIPTION
Ensure users of `asdf` can have exactly the same versions of erlang and elixir compiled with that version of erlang.
`asdf install`

If not needed.  Please close freely :)